### PR TITLE
add gitignore for jspm

### DIFF
--- a/data/custom/jspm.gitignore
+++ b/data/custom/jspm.gitignore
@@ -1,0 +1,1 @@
+jspm_packages


### PR DESCRIPTION
I'd like to propose adding a gitignore for the [jspm](http://www.jspm.io) package manager.