### PR TITLE
Add gitignore for Carthage

### DIFF
--- a/data/custom/Carthage.gitignore
+++ b/data/custom/Carthage.gitignore
@@ -1,0 +1,3 @@
+# Carthage - A simple, decentralized dependency manager for Cocoa
+Carthage.checkout
+Carthage.build


### PR DESCRIPTION
Lately i am using Carthage for dependency management and noted that your project was was missing a carthage gitignore file, so i created this pull request.