### PR TITLE
Update Laravel.gitignore for Laravel 5

### DIFF
--- a/data/custom/Laravel.gitignore
+++ b/data/custom/Laravel.gitignore
@@ -1,6 +1,8 @@
 /bootstrap/compiled.php
 /vendor
+/node_modules
 .env.local.php
 .env.php
+.env
 composer.phar
 composer.lock


### PR DESCRIPTION
Update file to include ignore files relevant to both Laravel 4 and Laravel 5 projects. Based on current .gitignore file ( see https://github.com/laravel/laravel/blob/master/.gitignore )