### PR TITLE
updated Libero SOC ignore

### DIFF
--- a/data/custom/LiberoSOC.gitignore
+++ b/data/custom/LiberoSOC.gitignore
@@ -1,4 +1,4 @@
-#Microsemi Libero SOC v11.3
+#Microsemi Libero SOC v11.5
 
 #ignore miscellaneous files in the following directories
 simulation/*
@@ -7,14 +7,13 @@ component/*
 tooldata/*
 viewdraw/*
 
-#auto-generated constraint files
+#auto-generated constraint log files
 constraint/*
 !constraint/**.sdc
 !constraint/**.pdc
 
 #synthesis log files
 synthesis/*
-!synthesis/*.edn
 
 #smartgen log files
 smartgen/*/*
@@ -23,8 +22,5 @@ smartgen/smartgen.ixf
 smartgen/smartgen.aws
 !smartgen/*/*.gen
 
-#designer log files
-#ignore designer files except the .adb file
+#designer files
 designer/*/*
-!designer/*/*.adb
-designer/*/*_r*_*


### PR DESCRIPTION
I've updated the Libro SOC ignore file to exclude more built files. Some of these files can get rather large and clog projects and they are not absolutely necessary to keep in tracking.