### PR TITLE
Remove tabindex -1 from Generate button

### DIFF
--- a/public/templates/index.dust
+++ b/public/templates/index.dust
@@ -20,8 +20,8 @@
   <div class="input-group">
       <input id="ignoreSearch" type="text" placeholder="{@pre type="content" key="searchPlaceholder"/}" tabindex="1" class="input form-control">
       <div class="input-group-btn">
-        <button type="button" tabindex="-1" onClick="generateGitIgnore()" class="btn btn-gitignore">Generate</button>
-        <button type="button" data-toggle="dropdown" tabindex="-1" class="btn btn-gitignore dropdown-toggle"><span class="caret"></span></button>
+        <button type="button" onClick="generateGitIgnore()" class="btn btn-gitignore">Generate</button>
+        <button type="button" data-toggle="dropdown" class="btn btn-gitignore dropdown-toggle"><span class="caret"></span></button>
         <ul role="menu" class="dropdown-menu pull-right">
           <li><a onClick="generateGitIgnoreFile()"><span class="icon-download"> Download File</span></a></li>
         </ul>


### PR DESCRIPTION
Having a `tabindex=-1` on both the Generate and dropdown buttons
means that they are unacessible via keyboard. That is very hurtful
for acessibility and downright annoying when using the website
instead of the cli helper function.