### PR TITLE
Added Phoenix .gitignore file

### DIFF
--- a/data/custom/phoenix.gitignore
+++ b/data/custom/phoenix.gitignore
@@ -1,0 +1,5 @@
+# Phoenix: a web framework for Elixir
+_build/
+deps/
+node_modules/
+priv/


### PR DESCRIPTION
Phoenix is a web framework for Elixir.
This .gitignore file ignores all the dependencies and compiled files by elixir, as
well as node_modules and compiled static sources in the priv directory (such
as compiled sass files).