### PR TITLE
Update gitignore entries for Django

### DIFF
--- a/data/custom/Django.gitignore
+++ b/data/custom/Django.gitignore
@@ -3,3 +3,5 @@
 *.pyc
 __pycache__/
 local_settings.py
+db.sqlite3
+media


### PR DESCRIPTION
A default install of Django sets the SQLite DB filename to be `db.sqlite3` which should be ignored and git and not replicated to other environments.

Also, `media` is a very common directory name where user-uploaded files are saved. This should also be ignored.