### PR TITLE
updates ignored files for Terraform

### DIFF
--- a/data/custom/Terraform.gitignore
+++ b/data/custom/Terraform.gitignore
@@ -1,2 +1,4 @@
 # Terraform - https://terraform.io/
 .terraform
+terraform.tfstate
+terraform.tfstate.backup


### PR DESCRIPTION
Terraform defaults to storing its state files locally but given the information they contain, they should not be committed.

I consider ignoring these files to be a _sane default_.