### PR TITLE
Add support for fastlane

### DIFF
--- a/data/custom/fastlane.gitignore
+++ b/data/custom/fastlane.gitignore
@@ -1,0 +1,14 @@
+# fastlane - A streamlined workflow tool for Cocoa deployment
+
+# fastlane specific
+fastlane/report.xml
+
+# deliver temporary files
+fastlane/Preview.html
+
+# snapshot generated screenshots
+fastlane/screenshots/**/*.png
+fastlane/screenshots/screenshots.html
+
+# scan temporary files
+fastlane/test_output


### PR DESCRIPTION
[fastlane](https://fastlane.tools) is a tool to connect all iOS deployment workflow. These folder/files should be ignored as [suggested](https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md).