### PR TITLE
Ignore all account files in Kirby2

### DIFF
--- a/data/custom/Kirby2.gitignore
+++ b/data/custom/Kirby2.gitignore
@@ -1,7 +1,8 @@
 ## Kirby 2 | http://getkirby.com
 
 # Exclude account information
-site/accounts/*.php
+site/accounts/*
+!site/accounts/index.html
 assets/avatars/*
 !assets/avatars/.gitkeep
 


### PR DESCRIPTION
Kirby prevents brute-force attacks with a `.logins` file in `site/accounts`, [see here](https://forum.getkirby.com/t/what-is-site-accounts-logins/3494). If this file doesn't exist, Kirby generates a new one. Tracking this file in git doesn't make much sense. It also could cause a conflict, if someone deploys Kirby with git.