### PR TITLE
Tweak to handling of LiberoSOC smartgen files

### DIFF
--- a/data/custom/LiberoSOC.gitignore
+++ b/data/custom/LiberoSOC.gitignore
@@ -17,10 +17,10 @@ synthesis/*
 
 #smartgen log files
 smartgen/*/*
-smartgen/*.ixf
-smartgen/smartgen.ixf
 smartgen/smartgen.aws
 !smartgen/*/*.gen
+!smartgen/*/*.vhd
+!smartgen/*/*.v
 
 #designer files
 designer/*/*


### PR DESCRIPTION
This is a more exclusive handling of the files in the smartgen folder. This will only keep the .vhd and .gen files that are needed.