### PR TITLE
Ignore Terraform tfvars files

### DIFF
--- a/data/custom/Terraform.gitignore
+++ b/data/custom/Terraform.gitignore
@@ -2,3 +2,4 @@
 .terraform
 terraform.tfstate
 terraform.tfstate.backup
+*.tfvars


### PR DESCRIPTION
Terraform can optionally load environment specific variables from a *.tfvars file,
by default a `terraform.tfvars` file.  These files may contain secrets.

See https://www.terraform.io/intro/getting-started/variables.html