### PR TITLE
Add Ember.gitignore

### DIFF
--- a/data/custom/Ember.gitignore
+++ b/data/custom/Ember.gitignore
@@ -1,0 +1,16 @@
+# see https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/gitignore
+# compiled output
+/dist
+/tmp
+
+# dependencies
+/node_modules
+/bower_components
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage/*
+/libpeerconnection.log
+npm-debug.log
+testem.log


### PR DESCRIPTION
[Ember.js](http://emberjs.com/) is "a framework for creating ambitious web applications". A command line interface exists to set an Ember project : [Ember CLI](http://ember-cli.com/). I took the gitignore file contents [here](https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/gitignore).