### PR TITLE
Remove misplaced \n

### DIFF
--- a/controllers/api/index.js
+++ b/controllers/api/index.js
@@ -70,7 +70,7 @@ function generateFile(ignoreString, list) {
             output += '\n#!! ERROR: ' + list[file] + ' is undefined. Use list command to see defined gitignore types !!#\n';
         } else {
             output += '\n### ' + DatastoreModel.JSONObject[list[file]].name + ' ###\n';
-            output += DatastoreModel.JSONObject[list[file]].contents + '\n';
+            output += DatastoreModel.JSONObject[list[file]].contents + (file < list.length - 1 ? '\n' : '');
         }
     }
     return output;


### PR DESCRIPTION
This removes 2, IMO, misplaced `\n`s:

1. The one in the "file header" seems to be placed there intentionally, though I'm not sure why. It causes the first line in my .gitignore files to be blank which I'm not a huge fan of.
2. I added a conditional to the `\n` that separates the different gitignore templates in 1 file so that the last one doesn't have a `\n` added. Apparently git doesn't want .gitignore files to end with `\n`.