### PR TITLE
Add tsconfig.json/jsconfig.json to Code.gitignore

### DIFF
--- a/data/custom/Code.gitignore
+++ b/data/custom/Code.gitignore
@@ -1,3 +1,5 @@
 # Visual Studio Code - https://code.visualstudio.com/
 .settings/
 .vscode/
+tsconfig.json
+jsconfig.json


### PR DESCRIPTION
Add tsconfig.json and jsconfig.json to data/custom/Code.gitignore

I know some projects want these files to be committed to git, but I think that because they are editor-specific files that are automatically generated for every project they should be excluded by default.