### PR TITLE
Fix URL of JabRef

### DIFF
--- a/data/custom/JabRef.gitignore
+++ b/data/custom/JabRef.gitignore
@@ -1,2 +1,2 @@
-# JabRef - http://jabref.sourceforge.net/
+# JabRef - http://www.jabref.org/
 *.bib.bak


### PR DESCRIPTION
Not sure, whether URLs should be included at all. But if, then they should point to the most recent one even though [Cool URIs don't change](https://www.w3.org/Provider/Style/URI).