### PR TITLE
Remove Tex.patch as the contained patch is already available at github

### DIFF
--- a/data/patch/Tex.patch
+++ b/data/patch/Tex.patch
@@ -1,3 +1,0 @@
-# pdfcomment
-.upa
-.upb


### PR DESCRIPTION
The contained patch for pdfcomment is already available at https://github.com/github/gitignore/blob/master/TeX.gitignore. Thus, this patch file is obsolete.