### PR TITLE
Add StackExchange's blackbox secret management

### DIFF
--- a/data/custom/Blackbox.gitignore
+++ b/data/custom/Blackbox.gitignore
@@ -1,0 +1,4 @@
+# https://github.com/StackExchange/blackbox
+/keyrings/live/pubring.gpg~
+/keyrings/live/pubring.kbx~
+/keyrings/live/secring.gpg


### PR DESCRIPTION
blackbox automatically adds these ignore lines to .gitignore if they are not
present already, so it should be safe to make gitignore.io to add it, there
will be no duplication.

See:
https://github.com/StackExchange/blackbox/blob/master/bin/blackbox_initialize#L30
https://github.com/StackExchange/blackbox/blob/master/bin/_blackbox_common.sh#L586-L595