### PR TITLE
Added Synology

### DIFF
--- a/data/custom/Synology.gitignore
+++ b/data/custom/Synology.gitignore
@@ -1,0 +1,4 @@
+# Thumbnails
+@eaDir
+# Recycle bin
+\#recycle


### PR DESCRIPTION
Synology NAS devices create some junk directories which is not easy or even
possible to remove.

https://www.synology.com/en-global/knowledgebase/DSM/help/DSM/AdminCenter/file_share_recycle
http://www.coderzen.com/2015/03/12/how-to-stop-your-synology-nas-from-junking-up-your-directories-with-eadir-directories/