### PR TITLE
Update ignored Carthage directory paths

### DIFF
--- a/data/custom/Carthage.gitignore
+++ b/data/custom/Carthage.gitignore
@@ -1,3 +1,3 @@
 # Carthage - A simple, decentralized dependency manager for Cocoa
-Carthage.checkout
-Carthage.build
+Carthage/Checkouts/
+Carthage/Build/


### PR DESCRIPTION
These must have changed somewhere in Carthage's history.
Carthage now nests Build and Checkouts directories under
a Carthage directory, rather than creating two directories
directly alongside the Cartfile.