### PR TITLE
Added Cmd/Ctrl+Enter functionality to search box

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -26,8 +26,17 @@ $(document).ready(function() {
         });
     });
     setTimeout(function () {
-      $(".select2-search__field").focus();
-    }, 10);
+        $(".select2-search__field").focus();
+    }, 100);
+    $(".ignoreSearch").on("select2:selecting", function(e) { 
+        setTimeout(function() {
+            $(".select2-search__field").keydown(function(e) {
+                if (e.keyCode == 13 && (e.metaKey || e.ctrlKey)) {
+                    generateGitIgnore();
+                }
+            });
+        }, 100);
+    });
 });
 
 function generateGitIgnore() {


### PR DESCRIPTION
I've picked up the habit of pressing Cmd+Enter to submit reddit comments and posts because of Reddit Enhancement Suite. Over time, I noticed that it's a somewhat standard keyboard shortcut across the web; even GitHub supports it. I miss it on gitignore.io, so I decided to build it in. This modification still supports the old Enter-to-select, but adds a new Cmd/Ctrl+Enter shortcut to submit the search query.

It was pretty tricky to implement.

I also increased the timeout time to focus the input box to 100ms, because 10ms was a hit or miss. Select2 seems to take approximately that long to set up its search box.