### PR TITLE
Add table for tools and extensions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Clients maintained by third-party developers
 | [gogi](https://github.com/Gnouc/gogi) | Go | [Install](https://github.com/Gnouc/gogi#installation) | [Cuong Manh Le](https://github.com/Gnouc) |
 | [ignr](https://github.com/Antrikshy/ignr.py) | Python | [Usage](https://github.com/Antrikshy/ignr.py#usage) | [Antriksh Yadav](https://github.com/Antrikshy) |
 
+Tools or extensions maintained by third-party developers on other platforms 
+
+| Source Code | Platform | Intructions | Maintainer
+|---|---|---|---|
+| [gi](https://marketplace.visualstudio.com/items?itemName=rubbersheep.gi) | Visual Studio Code | [Install](https://marketplace.visualstudio.com/items?itemName=rubbersheep.gi#install) | [Hasit Mistry](https://github.com/hasit/)
+
+
 # Use Command Line
 
 After the function is created, the `gi` command will give you command line access to the gitingore.io API. . **Note:** Use `gig` if you are on Windows


### PR DESCRIPTION
Add a subsection to 'Other Clients' section where people can list tools and extensions that are built on top of/use the gitignore.io API. 