### PR TITLE
Update JabRef.gitignore

### DIFF
--- a/data/custom/JabRef.gitignore
+++ b/data/custom/JabRef.gitignore
@@ -1,2 +1,3 @@
-# JabRef - http://www.jabref.org/
+# JabRef - https://www.jabref.org/
 *.bib.bak
+*.bib.swp


### PR DESCRIPTION
 * `.bib.swp` is the new autosave file of the upcoming JabRef 3.7 release
 * www.jabref.org now supports SSL