### PR TITLE
Update JabRef.gitignore

### DIFF
--- a/data/custom/JabRef.gitignore
+++ b/data/custom/JabRef.gitignore
@@ -1,3 +1,3 @@
 # JabRef - https://www.jabref.org/
-*.bib.bak
-*.bib.swp
+*.bak
+*.sav


### PR DESCRIPTION
The JabRef developers changed the extension in their development version again. Now, WinEdt is followed. There, the default setting is `.sav` and `.bak`. See https://github.com/github/gitignore/blob/master/TeX.gitignore#L183 and https://github.com/JabRef/jabref/pull/2188.

Updates #250