### PR TITLE
Added JMeter gitignore

### DIFF
--- a/data/custom/JMeter.gitignore
+++ b/data/custom/JMeter.gitignore
@@ -1,0 +1,11 @@
+# JMeter common ignore files
+# http://jmeter.apache.org/
+
+# Ignore Summary/Aggregrate reports
+*.jtl
+
+# Ignore log files
+*.log
+
+# Ignore customized user.properties
+user.properties


### PR DESCRIPTION
JMeter is a tool for performing Load/Performance testing. Usually, their TestCases which are JMX files can be committed as a Git Repository.

This simple gitignore makes it better for ignoring common ignore files for the same.