### PR TITLE
Let users copy a cURL command to write gitignore to file

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -59,3 +59,17 @@ function generateGitIgnoreFile() {
         window.location = "/api/f/" + uriEncodedFiles;
     }
 }
+
+function generateGitIgnoreCommand() {
+    var searchString = $(".ignoreSearch").val();
+    var searchLength = searchString.length;
+    if (searchLength > 0) {
+        var files = searchString.replace(/^,/, '');
+        var uriEncodedFiles = encodeURIComponent(files);
+
+        var url = "https://www.gitignore.io/api/" + uriEncodedFiles;
+        var command = "curl -s  \"" + url + "\" >> .gitignore && echo \"===\nYour gitignore file is all set up!\n===\"";
+
+        window.prompt('Below command appends to the gitignore file in your current directory', command);
+    }
+}

--- a/public/templates/index.dust
+++ b/public/templates/index.dust
@@ -24,6 +24,7 @@
             <button type="button" data-toggle="dropdown" class="btn btn-gitignore dropdown-toggle"><span class="caret"></span></button>
             <ul role="menu" class="dropdown-menu pull-right">
               <li><a onClick="generateGitIgnoreFile()"><span class="icon-download"> Download File</span></a></li>
+              <li><a onClick="generateGitIgnoreCommand()"><span class="icon-download"> Save With cURL</span></a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Added a simple option underneath the "Download File" option that shows the user the command to write the gitignore to a file right away, using cURL. Command generated looks as follows:

`curl -s  "https://www.gitignore.io/api/macos" >> .gitignore && echo "===
Your gitignore file is all set up!
==="`
<img width="772" alt="screen shot 2016-12-27 at 19 52 02" src="https://cloud.githubusercontent.com/assets/9115513/21506118/0435b796-cc6e-11e6-98b4-7956370873af.png">
