### PR TITLE
Remove non-existing plugin-dirs

### DIFF
--- a/data/custom/Shopware.gitignore
+++ b/data/custom/Shopware.gitignore
@@ -42,7 +42,3 @@ Thumbs.db
 
 # SASS/SCSS cache
 .sass-cache/
-
-# Internal Repositories
-/internal/
-/engine/Shopware/Plugins/Commercial/


### PR DESCRIPTION
Both `/internal/` as well as `/engine/Shopware/Plugins/Commercial/` don't exist in a default Shopware-installation at all.