### PR TITLE
Add CLI installation instructions in fish on Linux & macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ $ echo "function gi() { curl -L -s https://www.gitignore.io/api/\$@ ;}" >> ~/.ba
 $ echo "function gi() { curl -L -s https://www.gitignore.io/api/\$@ ;}" >> ~/.zshrc && source ~/.zshrc
 ```
 
+`#!/bin/fish`
+```sh
+$ printf "function gi\n\tcurl -L -s https://www.gitignore.io/api/\$argv\nend\n" > ~/.config/fish/functions/gi.fish
+```
+
 ### macOS
 `#!/bin/bash`
 ```sh
@@ -44,6 +49,11 @@ $ echo "function gi() { curl -L -s https://www.gitignore.io/api/\$@ ;}" >> ~/.ba
 `#!/bin/zsh`
 ```sh
 $ echo "function gi() { curl -L -s https://www.gitignore.io/api/\$@ ;}" >> ~/.zshrc && source ~/.zshrc
+```
+
+`#!/bin/fish`
+```sh
+$ printf "function gi\n\tcurl -L -s https://www.gitignore.io/api/\$argv\nend\n" > ~/.config/fish/functions/gi.fish
 ```
 
 ### Windows


### PR DESCRIPTION
It creates an [autoloading function](https://fishshell.com/docs/current/tutorial.html#tut_autoload) in [fish shell](https://fishshell.com). Sourcing it is not required as fish shell autoloads functions.

Notes:
* Using `printf` for [better](http://unix.stackexchange.com/questions/65803/why-is-printf-better-than-echo) new-line (`\n`) support instead of `echo`. New-lines make the function more human-readable.
* Using `>` as `gi.fish` should only contain this one function. Hence, appending to the file is not required.

Testing:
* ✅ Manually tested on macOS Sierra v10.12.3 (16D32) with iTerm2 v3.0.13 with fish shell v2.5.0.
* ❌ Was not able to test on Linux.

Suggestions for improvement are welcome! Thanks!