### PR TITLE
Add relative derived data for Xcode projects

### DIFF
--- a/data/custom/SwiftPackageManager.gitignore
+++ b/data/custom/SwiftPackageManager.gitignore
@@ -2,3 +2,4 @@ Packages
 .build
 xcuserdata
 *.xcodeproj
+DerivedData

--- a/data/custom/Xcode.gitignore
+++ b/data/custom/Xcode.gitignore
@@ -3,3 +3,4 @@ build
 !*.xcodeproj/project.pbxproj
 !*.xcworkspace/contents.xcworkspacedata
 /*.gcno
+DerivedData/


### PR DESCRIPTION
This PR adds the `DerivedData` directory to the gitignore for those who have Relative Derived Data configured in Xcode