### PR TITLE
Update Crystal .gitignore

### DIFF
--- a/data/custom/Crystal.gitignore
+++ b/data/custom/Crystal.gitignore
@@ -1,10 +1,8 @@
-/.deps/
-/libs/
-/.crystal/
 /doc/
-
+/lib/
+/bin/
+/.shards/
 
 # Libraries don't need dependency lock
 # Dependencies will be locked in application that uses them
-# Uncomment the line below if you are creating a library.
-#/.deps.lock
+#/shard.lock


### PR DESCRIPTION
Crystal introduce `shards` as it's default dependency management system, so .gitignore was updated.