### PR TITLE
Update Kentico ignore

### DIFF
--- a/data/custom/Kentico.gitignore
+++ b/data/custom/Kentico.gitignore
@@ -3,23 +3,26 @@
 # Include some Kentico folders excluded by Visual Studio rules
 !CMS/CMSAdminControls/*/
 !CMS/CMSModules/System/*/
+!CMS/App_Data/CIRepository/**
 
 # Kentico temporary/environment files
 CMS/App_Data/AzureCache
 CMS/App_Data/AzureTemp
 CMS/App_Data/CMSModules/DeviceProfile/logFiftyOne.txt
+CMS/App_Data/CMSModules/DeviceProfiles/logFiftyOne.txt
 CMS/App_Data/CMSModules/WebFarm/webfarm.sync
 CMS/App_Data/CMSTemp
 CMS/App_Data/Persistent
 CMS/CMSSiteUtils/Export
 CMS/CMSSiteUtils/Import
 
-# Ignore all smart search indexes, but not the other systme folder contents
+# Ignore all smart search indexes, but not the other system folder contents
 CMS/App_Data/CMSModules/SmartSearch/**
 !CMS/App_Data/CMSModules/SmartSearch/*/
 !CMS/App_Data/CMSModules/SmartSearch/_StopWords/**
 !CMS/App_Data/CMSModules/SmartSearch/_Synonyms/**
 
+## Kentico Starter Sites
 # Starter site resource Files
 CMS/App_Data/DancingGoat
  
@@ -49,6 +52,7 @@ CMS/EcommerceSite
 CMS/IntranetPortal
 CMS/PersonalSite
 
+## Project specific ignores
 # Sensitive settings
 AppSettings.config
 ConnectionStrings.config


### PR DESCRIPTION
Adds an include rule for default continuous integration folder, a new rule for an updated path in version 10, a few headers, and fixes a typo.