### PR TITLE
Add newline between last template line and closing comment.

### DIFF
--- a/Sources/GitignoreIOServer/RouteHandlers/APIRouteHandlers.swift
+++ b/Sources/GitignoreIOServer/RouteHandlers/APIRouteHandlers.swift
@@ -107,7 +107,7 @@ internal class APIHandlers {
             .reduce("\n# Created by https://www.gitignore.io/api/\(ignoreString)\n") { (currentTemplate, contents) -> String in
                 return currentTemplate.appending(contents)
             }
-            .appending("\n# End of https://www.gitignore.io/api/\(ignoreString)\n")
+            .appending("\n\n# End of https://www.gitignore.io/api/\(ignoreString)\n")
             .removeDuplicateLines()
     }
 


### PR DESCRIPTION
It's a small thing, but I find the lack of a newline before the closing comment makes the final line of the template code harder to read. This just makes the closing comment more consistent with the opening one.