### PR TITLE
Add order API endpoint

### DIFF
--- a/Sources/App/Controllers/TemplateController.swift
+++ b/Sources/App/Controllers/TemplateController.swift
@@ -42,7 +42,7 @@ internal struct TemplateController: ReadOnlyTemplateManagerProtocol {
                 line.trimmingCharacters(in: .whitespaces).lowercased()
             })
             .filter({ (line) -> Bool in
-                !line.hasPrefix("#") || !line.hasPrefix("")
+                !line.hasPrefix("#") && !line.isEmpty
             })
             .enumerated()
             .reduce([String: Int](), { (orderedDict, line : (offset: Int, text: String)) -> [String: Int] in

--- a/Sources/App/RouteHandlers/APIRouteHandlers.swift
+++ b/Sources/App/RouteHandlers/APIRouteHandlers.swift
@@ -62,7 +62,6 @@ internal class APIHandlers {
     ///
     /// - Parameter router: Vapor server side Swift router
     internal func createListEndpoint(router: Router) {
-
         router.get("/api/list") { request -> Response in
             let response = request.makeResponse()
 
@@ -83,6 +82,17 @@ internal class APIHandlers {
             case "json": try response.content.encode(json: self.templates)
             default: try response.content.encode("Unknown Format: `lines` or `json` are acceptable formats")
             }
+            return response
+        }
+    }
+
+    /// Create the API endpoint for showing th eorder of templates
+    ///
+    /// - Parameter router: Vapor server side Swift router
+    internal func createOrderEndpoint(router: Router) {
+        router.get("/api/order") { request -> Response in
+            let response = request.makeResponse()
+            try response.content.encode(json: self.order)
             return response
         }
     }

--- a/Sources/App/Server.swift
+++ b/Sources/App/Server.swift
@@ -62,6 +62,7 @@ public class Gitignore {
         apiHandlers.createIgnoreEndpoint(router: router)
         apiHandlers.createTemplateDownloadEndpoint(router: router)
         apiHandlers.createListEndpoint(router: router)
+        apiHandlers.createOrderEndpoint(router: router)
         apiHandlers.createHelp(router: router)
     }
 

--- a/Tests/AppTests/RouteHandlers/APIHandlersTests.swift
+++ b/Tests/AppTests/RouteHandlers/APIHandlersTests.swift
@@ -24,6 +24,7 @@ class APIHandlersTests: XCTestCase {
         ("testServer_api_force_sort_sortable", testServer_api_force_sort_sortable),
         ("testServer_api_no_sort_sortalbe", testServer_api_no_sort_sortalbe),
         ("testServer_api_no_sort_not_sortable", testServer_api_no_sort_not_sortable),
+        ("testServer_api_order", testServer_api_order),
         ("testServer_api", testServer_api),
     ]
 
@@ -111,13 +112,21 @@ class APIHandlersTests: XCTestCase {
         }
     }
 
-    func testSErver_api_url_multiple_url_encoded() throws {
+    func testServer_api_url_multiple_url_encoded() throws {
         let body = try responseForRequest("/api/sbt%2Cscala%2Cintellij").http.body
         XCTAssertFalse(body.description.contains("!! ERROR:"))
         XCTAssertTrue(body.description.contains("### SBT ###"))
         XCTAssertTrue(body.description.contains("### Scala ###"))
         XCTAssertTrue(body.description.contains("### Intellij ###"))
         if let byteCount = body.count {
+            XCTAssertGreaterThan(byteCount, 0)
+        } else {
+            XCTFail()
+        }
+    }
+
+    func testServer_api_order() throws {
+        if let byteCount = try responseForRequest("/api/order").http.body.count {
             XCTAssertGreaterThan(byteCount, 0)
         } else {
             XCTFail()


### PR DESCRIPTION
Add `/api/order` endpoint for services which want to sort templates the same way gitignore.io does.