### PR TITLE
Add url params to gitignore.io

### DIFF
--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -9,7 +9,13 @@ $.ajax('/dropdown/templates.json').success(data => {
         theme: "bootstrap",
         multiple: true,
         data
-    });                                                                            
+    });
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const preFilledSearchTerms = urlParams.get("keywords").split(",").map(val => val.toLowerCase())
+    const validIDs = new Set(data.map(datum => datum.id))
+    const validPreFilledSearchTerms = preFilledSearchTerms.filter(term => validIDs.has(term))
+    $(".ignore-search").val(validPreFilledSearchTerms).trigger('change.select2');
 });
 
 

--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -12,7 +12,7 @@ $.ajax('/dropdown/templates.json').success(data => {
     });
 
     const urlParams = new URLSearchParams(window.location.search);
-    const preFilledSearchTerms = urlParams.get("keywords").split(",").map(val => val.toLowerCase())
+    const preFilledSearchTerms = urlParams.get("templates").split(",").map(val => val.toLowerCase())
     const validIDs = new Set(data.map(datum => datum.id))
     const validPreFilledSearchTerms = preFilledSearchTerms.filter(term => validIDs.has(term))
     $(".ignore-search").val(validPreFilledSearchTerms).trigger('change.select2');


### PR DESCRIPTION
Added URL Params so keywords can be populated on first load. On loading `templates.json`, it’ll now extract URLParams and filter out those params that exist in the templates. It’ll then “fill” them in the `select2` Search box.

Signed-off-by: Robin Malhotra <me@rmalhotra.com>