### PR TITLE
Fix #435 by adding encodeURIComponent()

### DIFF
--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -12,7 +12,7 @@ $.ajax('/dropdown/templates.json').success(data => {
     });
 
     const urlParams = new URLSearchParams(window.location.search);
-    const preFilledSearchTerms = urlParams.get("templates").split(",").map(val => val.toLowerCase())
+    const preFilledSearchTerms = urlParams.get("templates").split(",").map(val => encodeURIComponent(val).toLowerCase())
     const validIDs = new Set(data.map(datum => datum.id))
     const validPreFilledSearchTerms = preFilledSearchTerms.filter(term => validIDs.has(term))
     $(".ignore-search").val(validPreFilledSearchTerms).trigger('change.select2');


### PR DESCRIPTION
This commit will fix #435 by adding `encodeURIComponent()` function to split values from `template` url parameter. The `+` letter in them will be url encoded. Some special characters are encoded as well: `, / ? : @ & = $ #`

I hope this commit will suffice to solve this problem.

cc. @codeOfRobin

### Reference

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
* #429