### PR TITLE
Fix #437 - the "+" letter problem

### DIFF
--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -12,7 +12,7 @@ $.ajax('/dropdown/templates.json').success(data => {
     });
 
     const urlParams = new URLSearchParams(window.location.search);
-    const preFilledSearchTerms = urlParams.get("templates").split(",").map(val => encodeURIComponent(val).toLowerCase())
+    const preFilledSearchTerms = urlParams.get("templates").split(",").map(val => val.replace(/\s/g, "+").toLowerCase())
     const validIDs = new Set(data.map(datum => datum.id))
     const validPreFilledSearchTerms = preFilledSearchTerms.filter(term => validIDs.has(term))
     $(".ignore-search").val(validPreFilledSearchTerms).trigger('change.select2');

--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -12,9 +12,9 @@ $.ajax('/dropdown/templates.json').success(data => {
     });
 
     const urlParams = new URLSearchParams(window.location.search);
-    const preFilledSearchTerms = urlParams.get("templates").split(",").map(val => val.replace(/\s/g, "+").toLowerCase())
-    const validIDs = new Set(data.map(datum => datum.id))
-    const validPreFilledSearchTerms = preFilledSearchTerms.filter(term => validIDs.has(term))
+    const preFilledSearchTerms = urlParams.get("templates").replace(/\s/g, "+").toLowerCase().split(",");
+    const validIDs = new Set(data.map(datum => datum.id));
+    const validPreFilledSearchTerms = preFilledSearchTerms.filter(term => validIDs.has(term));
     $(".ignore-search").val(validPreFilledSearchTerms).trigger('change.select2');
 });
 


### PR DESCRIPTION
Pull request #437 actually didn't solve the closed issue #435 because I understood the problem wrong. This problem was not about url encoding.

`URLSearchParams` object returns invalid id of `gitignore.io` template not because the object didn't recognize `+` letters, but because it ACTUALLY recognized them and switched them to SPACES(` `).

To solve the problem correctly, this pull request changes strategy to replace spaces to `+` in url parameter, so the filter is able to find proper id from template set.

This pull request also includes small refactoring in `app.js`.

cc. @codeOfRobin 

### Reference

* https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams